### PR TITLE
Update to Terraform 0.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 functions/pkg/
 terraform/.terraform/
+terraform/.terraform.lock.hcl
 terraform/terraform.tfvars
 terraform/terraform-local.tf
 venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.3.0 (Unreleased)
+
+IMPROVEMENTS:
+
+* Update Terraform to 0.15.
+* Update AWS provider to 3.29.1.
+* Update Archive provider to 2.1.0.
+* Update Random provider to 3.1.0.
+
 # 1.2.1 (August 22, 2020)
 
 IMPROVEMENTS:

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -11,7 +11,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.29.1"
+      version = "~> 3.36.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -2,20 +2,20 @@
 # Copy that file to terraform-local.tf.
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 0.15.0"
 
   required_providers {
     archive = {
       source  = "hashicorp/archive"
-      version = "~> 1.3.0"
+      version = "~> 2.1.0"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.3.0"
+      version = "~> 3.29.1"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.3.0"
+      version = "~> 3.1.0"
     }
   }
 }


### PR DESCRIPTION
Routine dependency upgrades. No breaking changes after two major Terraform versions! 🎉

Requires running `terraform init -upgrade`.